### PR TITLE
update to use LogRoller 0.4

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,10 +1,9 @@
 environment:
   matrix:
-  - julia_version: 1.0
-  - julia_version: 1.1
   - julia_version: 1.2
   - julia_version: 1.3
   - julia_version: 1.4
+  - julia_version: 1.5
   - julia_version: nightly
 
 platform:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,10 @@ os:
   - osx
 
 julia:
-  - 1.0
-  - 1.1
   - 1.2
   - 1.3
   - 1.4
+  - 1.5
   - nightly
 
 # # Uncomment the following lines to allow failures on nightly julia

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "35b68a49-52b3-46cc-a782-1725e63e5e62"
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
 license = "MIT"
 desc = "Enable LogRoller for LogCompose"
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 LogCompose = "8416b438-731e-11ea-2421-05f642269042"
@@ -12,7 +12,7 @@ LogRoller = "c41e01d8-14e5-11ea-185b-e7eabed7be4b"
 
 [compat]
 julia = "1"
-LogRoller = "0.3"
+LogRoller = "0.4"
 LogCompose = "0.2"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ Example configurations:
 type = "LogRoller.RollingLogger"
 filename = "testapp.log"
 # sizelimit = 10240000
+# entry_sizelimit = 262144
 # nfiles = 5
 # min_level = "Debug"                   # Debug, Info (default) or Error
 # timestamp_identifier = "time"
+# format = "console"                    # console or json
 
 [loggers.rollingfile]
 type = "LogRoller.RollingFileWriter"

--- a/src/LogRollerCompose.jl
+++ b/src/LogRollerCompose.jl
@@ -12,9 +12,13 @@ function logcompose(::Type{LogRoller.RollingLogger}, config::Dict{String,Any}, l
     level = log_min_level(logger_config, "Info")
     sizelimit = get(logger_config, "sizelimit", 10240000)
     nfiles = get(logger_config, "nfiles", 5)
+    format = Symbol(get(logger_config, "format", "console"))
+    @assert format in (:json, :console)
+    entry_size_limit = get(logger_config, "entry_sizelimit", LogRoller.DEFAULT_MAX_LOG_ENTRY_SIZE)
+    @assert entry_size_limit > 0
     timestamp_identifier = Symbol(get(logger_config, "timestamp_identifier", "time"))
 
-    LogRoller.RollingLogger(filename, sizelimit, nfiles, level; timestamp_identifier=timestamp_identifier)
+    LogRoller.RollingLogger(filename, sizelimit, nfiles, level; timestamp_identifier=timestamp_identifier, format=format, entry_size_limit=entry_size_limit)
 end
 
 function logcompose(::typeof(LogRoller.RollingFileWriterTee), config::Dict{String,Any}, logger_config::Dict{String,Any})


### PR DESCRIPTION
update to accept additional configuration parameters for JSON formatting and log entry size limit introduced in LogRoller 0.4